### PR TITLE
I realized that after the POST request was completed, self.headers was modified.

### DIFF
--- a/tumblpy.py
+++ b/tumblpy.py
@@ -264,10 +264,10 @@ class Tumblpy(object):
                 resp = {'status': 200}
                 content = req.read()
             else:
-                resp, content = self.client.request(url, 'POST', urllib.urlencode(params), headers=self.headers)
+                resp, content = self.client.request(url, 'POST', urllib.urlencode(params), headers=self.headers.copy())
         else:
             url = '%s?%s' % (url, urllib.urlencode(params))
-            resp, content = self.client.request(url, 'GET', headers=self.headers)
+            resp, content = self.client.request(url, 'GET', headers=self.headers.copy())
 
         try:
             # If it is an avatar we need to check the HEAD of the request


### PR DESCRIPTION
This ensures the headers are never changed and thus allowing the following GET requests to complete successfully.

I was receiving TumblpyAuthErrors after running a t.post('user/info') followed by a t.get('followers', blog_url=blog['url']). Now it's all good.

This was what self.headers was returning after the original t.post() request:
{'Content-Type': 'application/x-www-form-urlencoded', 'User-agent': 'Tumblpy 0.5.0'}.

Now it only returns:
{'User-agent': 'Tumblpy 0.5.0'}

Thanks again for your great api code!
