### PR TITLE
Handle empty/ 404 responses

### DIFF
--- a/tumblpy.py
+++ b/tumblpy.py
@@ -237,7 +237,7 @@ class Tumblpy(object):
 
         if response.status_code < 200 or response.status_code > 301:
             error_message = ''
-            if content.get('errors') or content.get('error'):
+            if content and (content.get('errors') or content.get('error')):
                 if 'errors' in content:
                     for error in content['errors']:
                         error_message = '%s ' % error


### PR DESCRIPTION
The Tumblr API returns and empty list (and not a dict) in some cases, e. g. if a blog was not found (404). In these case, calling content.get() raises an AttributeError. This commit fixes it.

Example for a 404 response:
http://api.tumblr.com/v2/blog/cocofuckedchanel.tumblr.com/posts/
