### PR TITLE
fixed problem with post requests 

### DIFF
--- a/tumblpy/api.py
+++ b/tumblpy/api.py
@@ -120,7 +120,7 @@ class Tumblpy(object):
             if method == 'get':
                 response = func(url, params=params, allow_redirects=False)
             else:
-                response = func(url, data=params, files=files,
+                response = func(url, params=params, data=params, files=files,
                                 allow_redirects=False)
         except requests.exceptions.RequestException:
             raise TumblpyError('An unknown error occurred.')


### PR DESCRIPTION
Post requests didn't include the type parameter, so they would fail. For instance, the example in the readme for posting an image didn't work.

I'm not sure if this is the best way to solve the problem, but it makes it so I can submit post requests to the api.
