### PR TITLE
Adding how to import

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,6 +31,13 @@ Installing Tumbply is simple:
 Usage
 -----
 
+Importing
+~~~~~~~~~
+
+.. code-block:: python
+    
+    from tumblpy import Tumblpy
+
 Authorization URL
 ~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
All the examples below assume this has been imported as such. I found this unclear so I thought it would be nice to be included in the readme.
