### PR TITLE
Relaxed version requirements for requests and oauthlib

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ if sys.argv[-1] == 'publish':
 setup(
     name='python-tumblpy',
     version=__version__,
-    install_requires=['requests==1.2.2', 'requests_oauthlib==0.3.2'],
+    install_requires=['requests>=1.2.2', 'requests_oauthlib>=0.3.2'],
     author='Mike Helmick',
     author_email='me@michaelhelmick.com',
     license=open('LICENSE').read(),


### PR DESCRIPTION
In order to resolve some problems associated with #27, I have been running Tumblpy with the current versions of the two libraries for about a day with no problems. However, my service only retrieves the follower list, and creates and updates posts, so it uses a small subset of the whole Tumblr API.
