### PR TITLE
Decode fix

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,3 @@
-##FORK
-
-
 Tumblpy
 =======
 

--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,6 @@
+##FORK
+
+
 Tumblpy
 =======
 

--- a/tumblpy/api.py
+++ b/tumblpy/api.py
@@ -60,8 +60,7 @@ class Tumblpy(object):
         if response.status_code != 200:
             raise TumblpyAuthError('Seems something couldn\'t be verified with your OAuth junk. Error: %s, Message: %s' % (response.status_code, response.content))
 
-        # added .decode to fix first step auth issues 
-        request_tokens = dict(parse_qsl( response.content.decode() ))
+        request_tokens = dict(parse_qsl(response.content.decode()))
         if not request_tokens:
             raise TumblpyError('Unable to decode request tokens.')
 
@@ -78,9 +77,11 @@ class Tumblpy(object):
     def get_authorized_tokens(self, oauth_verifier):
         """Returns authorized tokens after they go through the auth_url phase.
         """
+
         response = self.client.get(self.access_token_url,
                                    params={'oauth_verifier': oauth_verifier})
-        authorized_tokens = dict(parse_qsl(response.content))
+        authorized_tokens = dict(parse_qsl(response.content.decode() ))
+
         if not authorized_tokens:
             raise TumblpyError('Unable to decode authorized tokens.')
 

--- a/tumblpy/api.py
+++ b/tumblpy/api.py
@@ -60,7 +60,12 @@ class Tumblpy(object):
         if response.status_code != 200:
             raise TumblpyAuthError('Seems something couldn\'t be verified with your OAuth junk. Error: %s, Message: %s' % (response.status_code, response.content))
 
-        request_tokens = dict(parse_qsl(response.content.decode()))
+        res = response.content
+        if isinstance( response.content, bytes ):
+            res = res.decode()
+
+        request_tokens = dict(parse_qsl(res))
+
         if not request_tokens:
             raise TumblpyError('Unable to decode request tokens.')
 
@@ -77,11 +82,14 @@ class Tumblpy(object):
     def get_authorized_tokens(self, oauth_verifier):
         """Returns authorized tokens after they go through the auth_url phase.
         """
-
         response = self.client.get(self.access_token_url,
                                    params={'oauth_verifier': oauth_verifier})
-        authorized_tokens = dict(parse_qsl(response.content.decode() ))
 
+        res = response.content
+        if isinstance( response.content, bytes ):
+            res = res.decode()
+
+        authorized_tokens = dict(parse_qsl(res))
         if not authorized_tokens:
             raise TumblpyError('Unable to decode authorized tokens.')
 

--- a/tumblpy/api.py
+++ b/tumblpy/api.py
@@ -60,7 +60,8 @@ class Tumblpy(object):
         if response.status_code != 200:
             raise TumblpyAuthError('Seems something couldn\'t be verified with your OAuth junk. Error: %s, Message: %s' % (response.status_code, response.content))
 
-        request_tokens = dict(parse_qsl(response.content))
+        # added .decode to fix first step auth issues 
+        request_tokens = dict(parse_qsl( response.content.decode() ))
         if not request_tokens:
             raise TumblpyError('Unable to decode request tokens.')
 


### PR DESCRIPTION
Fix issues with GET requests in get_authentication_tokens and get_authorized_tokens returns value in bytes and needed to be decoded before response data can be worked with.

The response.content would return an dict with the keys and values encoded;
```python
{b'oauth_token': b'Yh...token...EQ', b'oauth_token_secret': b'YH...token...gO', b'oauth_callback_confirmed': b'true'}
```