### PR TITLE
Parsing blog URL

### DIFF
--- a/tumblpy/api.py
+++ b/tumblpy/api.py
@@ -108,9 +108,11 @@ class Tumblpy(object):
 
         if blog_url is not None:
             # http://api.tumblr.com/v2/blog/blogname.tumblr.com/
-            blog_url = blog_url.rstrip('/')
-            if blog_url.startswith('http://'):
-                blog_url = blog_url[7:]
+            blog_url = urlparse(blog_url)
+            url = '%sblog/%s/' % (
+                self.api_url,
+                blog_url.hostname if blog_url.hostname is not None else blog_url.path
+            )
 
             url = '%sblog/%s/' % (self.api_url, blog_url)
 


### PR DESCRIPTION
Fixes #39 and #45 - blog URL was not parsed properly if the blog is served over HTTPS.